### PR TITLE
T-018, T-019: Property and metamorphic oracles, function selection

### DIFF
--- a/src/qallm/cli.py
+++ b/src/qallm/cli.py
@@ -342,74 +342,109 @@ def cmd_full(args) -> None:
     workspace = SessionService.workspace_active_dir(session_id)
     py_files = list(workspace.rglob("*.py"))
 
+    verification_sessions = []
+    total_bugs = 0
+    gen_model_name = ""
+    gen_rounds = 0
+    all_functions = []
+
     if not py_files:
         print("Step 3: Generate tests (skipped, no Python files)\n", file=sys.stderr)
     else:
-        # Count functions first
-        all_functions = []
         for py_file in py_files:
             source_code = py_file.read_text(encoding="utf-8")
             funcs = extract_functions_from_source(source_code, filepath=str(py_file))
             for func in funcs:
                 all_functions.append((py_file, func))
 
-        func_names = [f.name for _, f in all_functions]
-        func_display = ", ".join(func_names[:10])
-        if len(func_names) > 10:
-            func_display += f" ... and {len(func_names) - 10} more"
+        if not all_functions:
+            print("Step 3: Generate tests (skipped, no extractable functions)\n", file=sys.stderr)
+        else:
+            # Show numbered function list
+            print(f"\n[QALLM] Found {len(all_functions)} function(s):", file=sys.stderr)
+            for i, (pf, fn) in enumerate(all_functions):
+                print(f"  [{i + 1}] {fn.name} ({pf.name}, line {fn.lineno})", file=sys.stderr)
 
-        print(f"[QALLM] Found {len(all_functions)} function(s): {func_display}", file=sys.stderr)
-        run_gen = skip_prompts or _confirm(f"Step 3: Generate tests for {len(all_functions)} function(s)?")
+            run_gen = skip_prompts or _confirm("\nStep 3: Generate tests?")
 
-        if run_gen:
-            if skip_prompts:
-                gen_model_name = args.model or "gpt-4o-mini"
-                gen_rounds = args.rounds
-            else:
-                gen_model_name = _choose_model(registry, default=args.model or "gpt-4o-mini")
-                gen_rounds_str = _prompt(f"  How many test generation rounds? [{args.rounds}]: ", str(args.rounds))
-                gen_rounds = int(gen_rounds_str) if gen_rounds_str.isdigit() else args.rounds
+            if run_gen:
+                # Function selection
+                if not skip_prompts and len(all_functions) > 1:
+                    selection = _prompt(
+                        "  Which functions? [all] or comma separated numbers (e.g. 1,3): ",
+                        "all",
+                    )
+                    if selection.lower() != "all":
+                        try:
+                            indices = [int(x.strip()) - 1 for x in selection.split(",")]
+                            all_functions = [all_functions[i] for i in indices if 0 <= i < len(all_functions)]
+                        except (ValueError, IndexError):
+                            print("  Invalid selection, using all functions.", file=sys.stderr)
+                    print(f"  Selected {len(all_functions)} function(s)", file=sys.stderr)
 
-            try:
-                llm = registry.pick(gen_model_name)
-            except ValueError:
-                raise SystemExit(f"Model '{gen_model_name}' not found. Available: {registry.list()}")
+                # Oracle selection
+                if skip_prompts:
+                    oracle_choice = getattr(args, "oracle", "crash")
+                else:
+                    oracle_choice = _prompt(
+                        "  Oracle type? [crash / property / metamorphic] (default: crash): ", "crash"
+                    )
+                    if oracle_choice not in ("crash", "property", "metamorphic"):
+                        print(f"  Unknown oracle '{oracle_choice}', using crash.", file=sys.stderr)
+                        oracle_choice = "crash"
 
-            if not llm.is_configured():
-                raise SystemExit(f"Model '{gen_model_name}' is not configured. Set the required API key.")
+                # Model and rounds
+                if skip_prompts:
+                    gen_model_name = args.model or "gpt-4o-mini"
+                    gen_rounds = args.rounds
+                else:
+                    gen_model_name = _choose_model(registry, default=args.model or "gpt-4o-mini")
+                    gen_rounds_str = _prompt(f"  How many test generation rounds? [{args.rounds}]: ", str(args.rounds))
+                    gen_rounds = int(gen_rounds_str) if gen_rounds_str.isdigit() else args.rounds
 
-            print(f"  Generating with {gen_model_name} ({gen_rounds} round(s))...\n", file=sys.stderr)
+                try:
+                    llm = registry.pick(gen_model_name)
+                except ValueError:
+                    raise SystemExit(f"Model '{gen_model_name}' not found. Available: {registry.list()}")
 
-            verification_sessions = []
-            total_bugs = 0
-            tests_dir = SessionService.generated_tests_dir(session_id)
+                if not llm.is_configured():
+                    raise SystemExit(f"Model '{gen_model_name}' is not configured. Set the required API key.")
 
-            for py_file, func in all_functions:
-                source_code = py_file.read_text(encoding="utf-8")
-                module_name = py_file.stem
-
-                loop = TestGenerationLoop(llm=llm, rounds=gen_rounds, timeout=args.timeout)
-                session = loop.run(func, source_code, module_name=module_name, persist_dir=tests_dir)
-                verification_sessions.append(asdict(session))
-                total_bugs += session.final_bugs
-
-                reports_dir = SessionService.reports_dir(session_id)
-                reports_dir.mkdir(parents=True, exist_ok=True)
-                save_session(session, reports_dir / f"verification_{func.name}.json")
-
-                cov = session.final_coverage or 0
                 print(
-                    f"  → {func.name}: coverage={cov:.0f}%, bugs={session.final_bugs}, rounds={len(session.rounds)}",
+                    f"  Generating with {gen_model_name}, oracle={oracle_choice}, {gen_rounds} round(s)...\n",
                     file=sys.stderr,
                 )
 
-            print("", file=sys.stderr)
-        else:
-            verification_sessions = []
-            total_bugs = 0
-            gen_model_name = ""
-            gen_rounds = 0
-            print("  → Skipped\n", file=sys.stderr)
+                tests_dir = SessionService.generated_tests_dir(session_id)
+
+                for py_file, func in all_functions:
+                    source_code = py_file.read_text(encoding="utf-8")
+                    module_name = py_file.stem
+
+                    loop = TestGenerationLoop(
+                        llm=llm,
+                        rounds=gen_rounds,
+                        oracle=oracle_choice,
+                        timeout=args.timeout,
+                    )
+                    session = loop.run(func, source_code, module_name=module_name, persist_dir=tests_dir)
+                    verification_sessions.append(asdict(session))
+                    total_bugs += session.final_bugs
+
+                    reports_dir = SessionService.reports_dir(session_id)
+                    reports_dir.mkdir(parents=True, exist_ok=True)
+                    save_session(session, reports_dir / f"verification_{func.name}.json")
+
+                    cov = session.final_coverage or 0
+                    print(
+                        f"  → {func.name}: coverage={cov:.0f}%, "
+                        f"bugs={session.final_bugs}, rounds={len(session.rounds)}",
+                        file=sys.stderr,
+                    )
+
+                print("", file=sys.stderr)
+            else:
+                print("  → Skipped\n", file=sys.stderr)
 
     # ── Report ────────────────────────────────────────────────────
     payload = {
@@ -516,6 +551,7 @@ def main() -> None:
     p_full.add_argument("--tools", nargs="*", help="Static analysis tools subset")
     p_full.add_argument("--model", default=None, help="LLM model (default: gpt-4o-mini)")
     p_full.add_argument("--rounds", type=int, default=5, help="Test generation rounds (default: 5)")
+    p_full.add_argument("--oracle", default="crash", help="Oracle type: crash, property, metamorphic (default: crash)")
     p_full.add_argument("--repair-rounds", type=int, default=None, help="Repair rounds (default: 1)")
     p_full.add_argument("--timeout", type=int, default=60, help="Test execution timeout in seconds")
     p_full.add_argument("-y", "--yes", action="store_true", help="Skip all prompts, use defaults")

--- a/src/qallm/verification/generator.py
+++ b/src/qallm/verification/generator.py
@@ -20,12 +20,16 @@ from qallm.verification.models import FunctionInfo, GeneratedTest, OracleType
 from qallm.verification.prompts import (
     SYSTEM_PROMPT,
     build_crash_oracle_prompt,
+    build_metamorphic_oracle_prompt,
+    build_property_oracle_prompt,
 )
 
 logger = logging.getLogger(__name__)
 
 PROMPT_BUILDERS = {
     "crash": build_crash_oracle_prompt,
+    "property": build_property_oracle_prompt,
+    "metamorphic": build_metamorphic_oracle_prompt,
 }
 
 

--- a/src/qallm/verification/prompts.py
+++ b/src/qallm/verification/prompts.py
@@ -79,27 +79,102 @@ def build_crash_oracle_prompt(func: FunctionInfo) -> str:
 
 
 def build_property_oracle_prompt(func: FunctionInfo) -> str:
-    """Build a user prompt for property oracle test generation.
+    """Build a user prompt for property oracle test generation (T-018).
 
     The property oracle focuses on: does the output satisfy invariants
-    derivable from the docstring and type hints? For example, a normalise
-    function should always return values in [0, 1].
-
-    Status: placeholder for T-018.
+    derivable from the docstring and type hints? For example, a sort
+    function should return a list of the same length, a normalise
+    function should return values in [0, 1].
     """
-    raise NotImplementedError("Property oracle prompt is T-018")
+    parts = [
+        "## Function under test\n",
+        f"```python\n{func.source}\n```\n",
+    ]
+
+    if func.docstring:
+        parts.append(f"## Docstring\n{func.docstring}\n")
+
+    if func.args:
+        arg_lines = []
+        for name, annotation in func.args:
+            if annotation:
+                arg_lines.append(f"  {name}: {annotation}")
+            else:
+                arg_lines.append(f"  {name}: (no type annotation)")
+        parts.append("## Arguments\n" + "\n".join(arg_lines) + "\n")
+
+    parts.append(
+        "## Task\n"
+        "Generate pytest test cases for the function above. Focus on the "
+        "property oracle: test whether the output satisfies invariants "
+        "and postconditions that can be inferred from the function's name, "
+        "docstring, type hints, and implementation.\n\n"
+        "Look for these kinds of properties:\n"
+        "  1. Type preservation: if the input is a list, is the output also a list?\n"
+        "  2. Size relationships: does the output have the same length as the input?\n"
+        "  3. Range constraints: is the output within expected bounds (e.g. 0 to 1, "
+        "non-negative, sorted)?\n"
+        "  4. Idempotency: does applying the function twice give the same result as once?\n"
+        "  5. Identity cases: does f(identity_element) return the expected identity result?\n"
+        "  6. Return type correctness: does the function return the type declared in "
+        "its signature?\n\n"
+        "For each test, write a clear assert that checks a specific property. "
+        "Use multiple different inputs to verify the property holds generally, "
+        "not just for one example.\n\n"
+        "Return ONLY the complete test file. Start with imports."
+    )
+
+    return "\n".join(parts)
 
 
 def build_metamorphic_oracle_prompt(func: FunctionInfo) -> str:
-    """Build a user prompt for metamorphic oracle test generation.
+    """Build a user prompt for metamorphic oracle test generation (T-019).
 
-    The metamorphic oracle focuses on: do related inputs produce consistently
-    related outputs? For example, sorting the input to a monotonic function
-    should yield sorted output.
-
-    Status: placeholder for T-019.
+    The metamorphic oracle focuses on: do related inputs produce
+    consistently related outputs? For example, sorting a permuted
+    input should yield the same sorted output.
     """
-    raise NotImplementedError("Metamorphic oracle prompt is T-019")
+    parts = [
+        "## Function under test\n",
+        f"```python\n{func.source}\n```\n",
+    ]
+
+    if func.docstring:
+        parts.append(f"## Docstring\n{func.docstring}\n")
+
+    if func.args:
+        arg_lines = []
+        for name, annotation in func.args:
+            if annotation:
+                arg_lines.append(f"  {name}: {annotation}")
+            else:
+                arg_lines.append(f"  {name}: (no type annotation)")
+        parts.append("## Arguments\n" + "\n".join(arg_lines) + "\n")
+
+    parts.append(
+        "## Task\n"
+        "Generate pytest test cases for the function above. Focus on the "
+        "metamorphic oracle: test whether RELATED inputs produce CONSISTENTLY "
+        "RELATED outputs.\n\n"
+        "A metamorphic relation is a known relationship between inputs and their "
+        "outputs. You don't need to know the exact expected output; you only need "
+        "to know how changing the input should change the output.\n\n"
+        "Look for these metamorphic relations:\n"
+        "  1. Additive: f(x + k) relates predictably to f(x)\n"
+        "  2. Multiplicative: f(k * x) relates predictably to f(x)\n"
+        "  3. Permutation: f(permute(x)) == f(x) for order-independent functions\n"
+        "  4. Negation/reversal: f(reverse(x)) relates to f(x)\n"
+        "  5. Subset: f(subset(x)) relates to f(x)\n"
+        "  6. Composition: f(a + b) relates to f(a) and f(b)\n"
+        "  7. Equivalence: different inputs that should produce the same output\n\n"
+        "Structure each test as:\n"
+        "  1. Create a source input and compute f(source)\n"
+        "  2. Transform the input according to a metamorphic relation\n"
+        "  3. Compute f(transformed) and assert the expected relationship\n\n"
+        "Return ONLY the complete test file. Start with imports."
+    )
+
+    return "\n".join(parts)
 
 
 def build_feedback_prompt(

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -211,3 +211,44 @@ def test_generate_replaces_module_name():
     result = gen.generate(_make_func(), module_name="my_analysis")
 
     assert "from my_analysis import" in result.test_code
+
+
+# -- Property and metamorphic oracle tests (T-018, T-019)
+
+
+def test_generate_property_oracle():
+    llm = FakeLLM(content=VALID_TEST_CODE)
+    gen = TestGenerator(llm)
+    result = gen.generate(_make_func(), oracle="property")
+
+    assert result.is_valid is True
+    assert result.oracle == "property"
+
+
+def test_generate_metamorphic_oracle():
+    llm = FakeLLM(content=VALID_TEST_CODE)
+    gen = TestGenerator(llm)
+    result = gen.generate(_make_func(), oracle="metamorphic")
+
+    assert result.is_valid is True
+    assert result.oracle == "metamorphic"
+
+
+def test_property_prompt_contains_invariant_guidance():
+    from qallm.verification.prompts import build_property_oracle_prompt
+
+    func = _make_func()
+    prompt = build_property_oracle_prompt(func)
+    assert "property oracle" in prompt.lower()
+    assert "invariant" in prompt.lower() or "postcondition" in prompt.lower()
+    assert "idempotency" in prompt.lower() or "Idempotency" in prompt
+
+
+def test_metamorphic_prompt_contains_relation_guidance():
+    from qallm.verification.prompts import build_metamorphic_oracle_prompt
+
+    func = _make_func()
+    prompt = build_metamorphic_oracle_prompt(func)
+    assert "metamorphic" in prompt.lower()
+    assert "relation" in prompt.lower()
+    assert "permutation" in prompt.lower() or "Permutation" in prompt


### PR DESCRIPTION
Adds two new oracle prompt strategies and interactive function selection.

**T-018: Property oracle**
Tests output invariants: type preservation, size relationships, range constraints,
idempotency, return type correctness. Usage: `--oracle property`

**T-019: Metamorphic oracle**
Tests input/output relationships: additive, multiplicative, permutation, negation,
subset, composition, equivalence. Usage: `--oracle metamorphic`

**Function selection in interactive full command**
Numbered function list with user selection (all or comma separated indices).
Oracle type prompt added to interactive flow. `--oracle` flag added to argparser.

4 new tests. Full suite: 301 passed.

Closes #T-018, #T-019