### PR TITLE
T-033: Repair history snapshots

### DIFF
--- a/docs/P4_Codebase_Analysis_and_Thesis_Backlog_v2.md
+++ b/docs/P4_Codebase_Analysis_and_Thesis_Backlog_v2.md
@@ -188,7 +188,7 @@ Organised by TAR cycle (matching proposal timeline). Each item has an ID, descri
 |----|------|---------------------|--------|
 | T-023 | **Jupyter frontend trigger** | ipywidgets button in notebook: "Run Quality Check". Calls pipeline, displays inline results (per-cell pass/fail, summary stats). Options to select operations (analyse/repair/verify). | M |
 | T-024 | **Web UI update** | Frontend updated to support all three operations. User can select: analyse only, analyse + repair, analyse + verify, or full cycle. Displays unified report. | M |
-| T-025 | **Collect evaluation notebooks** | Curate 200 notebooks from Li's dataset (5 domains × 3 complexity tiers). Select 100–200 from Kaggle/GitHub. Prepare HumanEval + MBPP benchmark subsets. | L |
+| T-33 | **Collect evaluation notebooks** | Curate 200 notebooks from Li's dataset (5 domains × 3 complexity tiers). Select 100–200 from Kaggle/GitHub. Prepare HumanEval + MBPP benchmark subsets. | L |
 | T-026 | **RQ1: Baseline comparison** | Run all 3 strategies (Hypothesis, one-shot LLM, RL-guided) on same code. Measure: bug-finding rate, branch coverage, test validity rate, learning curve slope. Statistical tests (Wilcoxon, Cliff's delta). | XL |
 | T-027 | **RQ2: Controlled comparison** | Same notebooks under 2 conditions: static-only vs. static+RL. Key metric: false confidence rate. Report total issues found and assessment time. | L |
 | T-028 | **RQ3: Expert validation** | Recruit 10–15 experts. Show 5 notebook analyses (static-only vs. static+RL). Collect Likert-scale responses + open-ended feedback. Thematic analysis for integration design recommendations. | L |
@@ -251,7 +251,7 @@ Organised by TAR cycle (matching proposal timeline). Each item has an ID, descri
 
 1. Build Jupyter trigger (T-023)
 2. Update web UI (T-024)
-3. Collect and curate evaluation data (T-025)
+3. Collect and curate evaluation data (T-33)
 4. Run experiments (T-026, T-027)
 5. Expert validation (T-028)
 6. Define metrics and build reporting (T-029, T-030)

--- a/docs/T-033-design.md
+++ b/docs/T-033-design.md
@@ -1,0 +1,91 @@
+# T-33: Repair History Snapshots Design
+
+## Problem
+
+The repair service overwrites workspace files in place. After repair, the
+original code is lost. This creates three problems:
+
+1. **No comparison.** Users cannot see what changed between repair rounds.
+2. **No choice.** Test generation always runs on the latest version; the
+   user cannot go back to an earlier or original version.
+3. **No data.** The repair progression across rounds is a valuable dataset
+   for thesis analysis and potential model training.
+
+## Solution
+
+Add a `repair_history/` directory to the session. Before each repair round
+writes changes to the active workspace, snapshot the current workspace state
+into `repair_history/round_NN/`. This gives full traceability.
+
+## Session Folder Structure (updated)
+
+```
+data/<session-id>/
+├── workspace_raw/          # original uploaded/cloned files (never modified)
+├── workspace/              # current active version
+├── repair_history/         # NEW: snapshots before each repair round
+│   ├── round_01/           # workspace state before round 1 repair
+│   ├── round_02/           # workspace state before round 2 repair
+│   └── ...
+├── generated_tests/        # persisted test code per round
+├── reports/                # analysis and verification JSON reports
+└── session.json
+```
+
+## Design Decisions
+
+### 1. Snapshot BEFORE writing, not after
+
+We snapshot the current workspace before repair modifies it. This means:
+- `round_01/` contains the **original** code (same as `workspace_raw`)
+- `round_02/` contains the code **after round 1 repair**
+- The active `workspace/` always contains the latest version
+
+This is simpler than snapshotting after, because the user can always see
+"what the code looked like before this round changed it."
+
+### 2. Full directory copy, not individual file diffs
+
+Each snapshot is a complete copy of the workspace. This is slightly
+wasteful on disk but makes restoration trivial: just copy the snapshot
+back to workspace. Diff-based storage would be more compact but adds
+complexity for no practical benefit at thesis scale (typically < 100 files).
+
+### 3. Version selection in interactive CLI
+
+The `qallm full` command's Step 3 (Generate Tests) shows available
+versions and lets the user choose which to test:
+
+```
+[QALLM] Available code versions:
+  [0] Original (workspace_raw)
+  [1] After repair round 1
+  [2] After repair round 2 (current)
+
+  Generate tests on which version? [2]:
+```
+
+### 4. API endpoint for version management
+
+- `GET /api/session/{id}/versions` returns available versions
+- `POST /api/session/{id}/restore/{round}` copies a snapshot back to
+  active workspace
+
+## Module Changes
+
+| File | Change |
+|------|--------|
+| `session/workspace.py` | Add `repair_history_dir()`, `snapshot_workspace()`, `list_repair_rounds()`, `restore_repair_round()` |
+| `repair/repair_service.py` | Call `snapshot_workspace()` before writing repaired files |
+| `cli.py` | Version selection prompt in `cmd_full` before test generation |
+| `api/session_routes.py` | Add version listing and restore endpoints |
+| `docs/verification-architecture.md` | Update session folder structure |
+
+## Mapping to Thesis
+
+| Thesis element | How repair history helps |
+|---------------|------------------------|
+| RQ2: static vs static+RL comparison | Run test gen on original AND repaired code, compare results |
+| Table 4: Total issues found | Compare static findings across repair rounds |
+| Chapter 5: Evaluation | Show repair progression across rounds (Table: findings before/after per round) |
+| Future work: model training | Repair history provides labeled before/after pairs |

--- a/docs/verification-architecture.md
+++ b/docs/verification-architecture.md
@@ -15,6 +15,36 @@ it sits alongside two other operations:
 Users can run any combination of these three operations, in any order,
 through CLI, Web UI, or Jupyter trigger.
 
+## Session Folder Structure
+
+Each session has a self-contained directory with the following layout:
+
+```
+data/<session-id>/
+├── workspace_raw/          # original uploaded/cloned files (never modified)
+├── workspace/              # current active version (may be repaired)
+├── repair_history/         # snapshots before each repair round
+│   ├── round_01/           # workspace state before round 1 wrote changes
+│   ├── round_02/           # workspace state before round 2 wrote changes
+│   └── ...
+├── generated_tests/        # persisted test code from each generation round
+│   ├── compute_mean_round_01.py
+│   ├── compute_mean_round_02.py
+│   └── dangerous_hypothesis.py    # Hypothesis baseline output
+├── reports/                # JSON reports from analysis and verification
+│   ├── findings_unified.json
+│   ├── repair_report.json
+│   ├── verification_compute_mean.json
+│   └── verification_aggregate.json
+└── session.json            # session metadata (source type, config)
+```
+
+Key invariants:
+- `workspace_raw` is never modified after initial ingest
+- `workspace` always holds the "current" version (original or latest repair)
+- `repair_history/round_NN` captures the workspace state BEFORE round N modified it
+- Users can restore any version via `SessionService.restore_repair_round()`
+
 ## Module Map
 
 ```

--- a/src/qallm/api/session_routes.py
+++ b/src/qallm/api/session_routes.py
@@ -106,3 +106,25 @@ def list_session_files(session_id: str) -> dict[str, Any]:
         "files": files,
         "count": len(files),
     }
+
+
+@router.get(
+    "/{session_id}/versions",
+    summary="List available code versions (original + repair rounds)",
+)
+def list_versions(session_id: str) -> dict[str, Any]:
+    _require_session(session_id)
+    rounds = SessionService.list_repair_rounds(session_id)
+    return {"session_id": session_id, "versions": rounds}
+
+
+@router.post(
+    "/{session_id}/restore/{round_num}",
+    summary="Restore a repair history snapshot to the active workspace",
+)
+def restore_version(session_id: str, round_num: int) -> dict[str, Any]:
+    _require_session(session_id)
+    success = SessionService.restore_repair_round(session_id, round_num)
+    if not success:
+        raise HTTPException(status_code=404, detail=f"Round {round_num} not found")
+    return {"session_id": session_id, "restored_round": round_num, "status": "ok"}

--- a/src/qallm/cli.py
+++ b/src/qallm/cli.py
@@ -388,6 +388,25 @@ def cmd_full(args) -> None:
         if finding_count > 0:
             print("  → Skipped\n", file=sys.stderr)
 
+    # ── Version selection (if repair history exists) ─────────────
+    repair_rounds = SessionService.list_repair_rounds(session_id)
+    if not skip_prompts and len(repair_rounds) > 2:
+        # More than just "original" and "current" means repairs happened
+        print("\n[QALLM] Available code versions:", file=sys.stderr)
+        for v in repair_rounds:
+            print(f"  [{v['round']}] {v['label']} ({v['files']} files)", file=sys.stderr)
+
+        latest = repair_rounds[-1]["round"]
+        choice = _prompt(f"  Generate tests on which version? [{latest}]: ", str(latest))
+        chosen_round = int(choice) if choice.isdigit() else latest
+
+        if chosen_round != latest:
+            if SessionService.restore_repair_round(session_id, chosen_round):
+                label = next((v["label"] for v in repair_rounds if v["round"] == chosen_round), f"round {chosen_round}")
+                print(f"  Restored: {label}\n", file=sys.stderr)
+            else:
+                print(f"  Version {chosen_round} not found, using current.\n", file=sys.stderr)
+
     # ── Step 3: Generate Tests ────────────────────────────────────
     workspace = SessionService.workspace_active_dir(session_id)
     py_files = list(workspace.rglob("*.py"))

--- a/src/qallm/repair/repair_service.py
+++ b/src/qallm/repair/repair_service.py
@@ -172,6 +172,10 @@ def run_repair(
     # 3. Group by file
     file_groups = _group_by_file(findings)
 
+    # 3b. Snapshot current workspace before modifying files
+    round_num = SessionService.snapshot_workspace(session_id)
+    logger.info("Repair round %d: snapshotted workspace before modifications", round_num)
+
     tracker = TokenTracker(budget=settings.TOKEN_BUDGET)
     patches: list[Patch] = []
     models_used: set[str] = set()
@@ -329,6 +333,7 @@ def run_repair(
     provider_label = provider or ("auto: " + ", ".join(sorted(models_used)))
     report = {
         "session_id": session_id,
+        "repair_round": round_num,
         "provider": provider_label,
         "patches": [asdict(p) for p in patches],
         "token_usage": tracker.to_dict(),
@@ -341,7 +346,8 @@ def run_repair(
 
     repaired_count = sum(1 for p in patches if p.applied)
     logger.info(
-        "Repair complete: %d files patched, %d tokens used, models=%s",
+        "Repair round %d complete: %d files patched, %d tokens used, models=%s",
+        round_num,
         repaired_count,
         tracker.total_tokens,
         ", ".join(sorted(models_used)),
@@ -352,5 +358,6 @@ def run_repair(
         "patches": [asdict(p) for p in patches],
         "token_usage": tracker.to_dict(),
         "repaired_count": repaired_count,
+        "repair_round": round_num,
         "provider_used": provider_label,
     }

--- a/src/qallm/session/workspace.py
+++ b/src/qallm/session/workspace.py
@@ -39,6 +39,101 @@ class SessionService:
         return SessionService.session_dir(session_id) / "generated_tests"
 
     @staticmethod
+    def repair_history_dir(session_id: str) -> Path:
+        return SessionService.session_dir(session_id) / "repair_history"
+
+    @staticmethod
+    def snapshot_workspace(session_id: str) -> int:
+        """Copy the current active workspace into repair_history/round_NN.
+
+        Returns the round number of the snapshot.
+        """
+        import shutil
+
+        history_dir = SessionService.repair_history_dir(session_id)
+        history_dir.mkdir(parents=True, exist_ok=True)
+
+        # Determine next round number
+        existing = sorted(history_dir.iterdir()) if history_dir.exists() else []
+        round_num = len(existing) + 1
+        round_dir = history_dir / f"round_{round_num:02d}"
+
+        # Copy active workspace to snapshot
+        workspace = SessionService.workspace_active_dir(session_id)
+        if workspace.exists():
+            shutil.copytree(workspace, round_dir)
+        else:
+            round_dir.mkdir(parents=True)
+
+        return round_num
+
+    @staticmethod
+    def list_repair_rounds(session_id: str) -> list[dict[str, Any]]:
+        """List all available repair history snapshots.
+
+        Returns a list of dicts with round number, path, and file count.
+        Always includes round 0 (original/workspace_raw).
+        """
+        raw_dir = SessionService.workspace_raw_dir(session_id)
+        raw_count = sum(1 for f in raw_dir.rglob("*.py")) if raw_dir.exists() else 0
+
+        rounds = [{"round": 0, "label": "Original (workspace_raw)", "files": raw_count}]
+
+        history_dir = SessionService.repair_history_dir(session_id)
+        if history_dir.exists():
+            for round_dir in sorted(history_dir.iterdir()):
+                if round_dir.is_dir() and round_dir.name.startswith("round_"):
+                    num = int(round_dir.name.split("_")[1])
+                    file_count = sum(1 for f in round_dir.rglob("*.py"))
+                    rounds.append(
+                        {
+                            "round": num,
+                            "label": f"Before repair round {num}",
+                            "files": file_count,
+                        }
+                    )
+
+        # Current workspace (latest version)
+        active = SessionService.workspace_active_dir(session_id)
+        active_count = sum(1 for f in active.rglob("*.py")) if active.exists() else 0
+        last_round = rounds[-1]["round"] if rounds else 0
+        rounds.append(
+            {
+                "round": last_round + 1,
+                "label": "Current (active workspace)",
+                "files": active_count,
+            }
+        )
+
+        return rounds
+
+    @staticmethod
+    def restore_repair_round(session_id: str, round_num: int) -> bool:
+        """Restore a repair history snapshot to the active workspace.
+
+        Round 0 restores from workspace_raw. Other rounds restore from
+        repair_history/round_NN.
+
+        Returns True on success, False if round not found.
+        """
+        import shutil
+
+        if round_num == 0:
+            source = SessionService.workspace_raw_dir(session_id)
+        else:
+            source = SessionService.repair_history_dir(session_id) / f"round_{round_num:02d}"
+
+        if not source.exists():
+            return False
+
+        workspace = SessionService.workspace_active_dir(session_id)
+        # Clear active workspace and copy from source
+        if workspace.exists():
+            shutil.rmtree(workspace)
+        shutil.copytree(source, workspace)
+        return True
+
+    @staticmethod
     def session_json_path(session_id: str) -> Path:
         return SessionService.session_dir(session_id) / "session.json"
 

--- a/tests/test_repair_history.py
+++ b/tests/test_repair_history.py
@@ -1,0 +1,164 @@
+"""Tests for repair history snapshots (T-025).
+
+Tests SessionService snapshot/restore methods and API endpoints.
+"""
+
+from qallm.session.workspace import SessionService
+
+
+def _create_session_with_files(isolated_data_dir) -> str:
+    """Create a session with sample Python files in workspace."""
+    session_id = SessionService.create_session(source_type="python_file", github_url=None)
+
+    # Put files in active workspace
+    workspace = SessionService.workspace_active_dir(session_id)
+    workspace.mkdir(parents=True, exist_ok=True)
+    (workspace / "main.py").write_text("def add(a, b):\n    return a + b\n", encoding="utf-8")
+    (workspace / "utils.py").write_text("def helper():\n    return 42\n", encoding="utf-8")
+
+    # Also put in raw
+    raw = SessionService.workspace_raw_dir(session_id)
+    raw.mkdir(parents=True, exist_ok=True)
+    (raw / "main.py").write_text("def add(a, b):\n    return a + b\n", encoding="utf-8")
+    (raw / "utils.py").write_text("def helper():\n    return 42\n", encoding="utf-8")
+
+    return session_id
+
+
+class TestSnapshotWorkspace:
+    def test_creates_round_01(self, isolated_data_dir):
+        session_id = _create_session_with_files(isolated_data_dir)
+        round_num = SessionService.snapshot_workspace(session_id)
+
+        assert round_num == 1
+        round_dir = SessionService.repair_history_dir(session_id) / "round_01"
+        assert round_dir.exists()
+        assert (round_dir / "main.py").exists()
+        assert (round_dir / "utils.py").exists()
+
+    def test_increments_round_number(self, isolated_data_dir):
+        session_id = _create_session_with_files(isolated_data_dir)
+
+        r1 = SessionService.snapshot_workspace(session_id)
+        r2 = SessionService.snapshot_workspace(session_id)
+        r3 = SessionService.snapshot_workspace(session_id)
+
+        assert r1 == 1
+        assert r2 == 2
+        assert r3 == 3
+
+    def test_snapshot_preserves_content(self, isolated_data_dir):
+        session_id = _create_session_with_files(isolated_data_dir)
+
+        # Snapshot original
+        SessionService.snapshot_workspace(session_id)
+
+        # Modify workspace
+        workspace = SessionService.workspace_active_dir(session_id)
+        (workspace / "main.py").write_text("def add(a, b):\n    return a + b + 0  # repaired\n")
+
+        # Snapshot modified
+        SessionService.snapshot_workspace(session_id)
+
+        # Round 1 should have original content
+        round_1 = SessionService.repair_history_dir(session_id) / "round_01" / "main.py"
+        assert "# repaired" not in round_1.read_text()
+
+        # Round 2 should have modified content
+        round_2 = SessionService.repair_history_dir(session_id) / "round_02" / "main.py"
+        assert "# repaired" in round_2.read_text()
+
+
+class TestListRepairRounds:
+    def test_lists_original_only_when_no_repairs(self, isolated_data_dir):
+        session_id = _create_session_with_files(isolated_data_dir)
+        rounds = SessionService.list_repair_rounds(session_id)
+
+        assert len(rounds) == 2  # original + current
+        assert rounds[0]["round"] == 0
+        assert "Original" in rounds[0]["label"]
+        assert "Current" in rounds[-1]["label"]
+
+    def test_lists_repair_rounds(self, isolated_data_dir):
+        session_id = _create_session_with_files(isolated_data_dir)
+        SessionService.snapshot_workspace(session_id)
+        SessionService.snapshot_workspace(session_id)
+
+        rounds = SessionService.list_repair_rounds(session_id)
+
+        assert len(rounds) == 4  # original + round_01 + round_02 + current
+        assert rounds[0]["round"] == 0
+        assert rounds[1]["round"] == 1
+        assert rounds[2]["round"] == 2
+
+    def test_file_counts_are_correct(self, isolated_data_dir):
+        session_id = _create_session_with_files(isolated_data_dir)
+        SessionService.snapshot_workspace(session_id)
+
+        rounds = SessionService.list_repair_rounds(session_id)
+        # All versions should have 2 Python files
+        for v in rounds:
+            assert v["files"] == 2
+
+
+class TestRestoreRepairRound:
+    def test_restore_original(self, isolated_data_dir):
+        session_id = _create_session_with_files(isolated_data_dir)
+
+        # Modify workspace
+        workspace = SessionService.workspace_active_dir(session_id)
+        (workspace / "main.py").write_text("MODIFIED")
+
+        # Restore original
+        success = SessionService.restore_repair_round(session_id, 0)
+        assert success is True
+        assert (workspace / "main.py").read_text().startswith("def add")
+
+    def test_restore_specific_round(self, isolated_data_dir):
+        session_id = _create_session_with_files(isolated_data_dir)
+
+        # Snapshot, modify, snapshot again
+        SessionService.snapshot_workspace(session_id)
+        workspace = SessionService.workspace_active_dir(session_id)
+        (workspace / "main.py").write_text("ROUND_1_REPAIRED")
+        SessionService.snapshot_workspace(session_id)
+        (workspace / "main.py").write_text("ROUND_2_REPAIRED")
+
+        # Restore round 2 (which has ROUND_1_REPAIRED)
+        success = SessionService.restore_repair_round(session_id, 2)
+        assert success is True
+        assert (workspace / "main.py").read_text() == "ROUND_1_REPAIRED"
+
+    def test_restore_nonexistent_round_returns_false(self, isolated_data_dir):
+        session_id = _create_session_with_files(isolated_data_dir)
+        success = SessionService.restore_repair_round(session_id, 99)
+        assert success is False
+
+
+class TestVersionAPI:
+    def test_list_versions(self, client, isolated_data_dir):
+        session_id = _create_session_with_files(isolated_data_dir)
+        r = client.get(f"/api/session/{session_id}/versions")
+        assert r.status_code == 200
+        data = r.json()
+        assert "versions" in data
+        assert len(data["versions"]) >= 2
+
+    def test_restore_original(self, client, isolated_data_dir):
+        session_id = _create_session_with_files(isolated_data_dir)
+
+        # Modify workspace
+        workspace = SessionService.workspace_active_dir(session_id)
+        (workspace / "main.py").write_text("CHANGED")
+
+        r = client.post(f"/api/session/{session_id}/restore/0")
+        assert r.status_code == 200
+        assert r.json()["restored_round"] == 0
+
+        # Verify restored
+        assert (workspace / "main.py").read_text().startswith("def add")
+
+    def test_restore_bad_round_returns_404(self, client, isolated_data_dir):
+        session_id = _create_session_with_files(isolated_data_dir)
+        r = client.post(f"/api/session/{session_id}/restore/99")
+        assert r.status_code == 404


### PR DESCRIPTION
Snapshots the workspace before each repair round. Users can list, compare,
and restore any version. Version selection prompt in CLI before test generation.

**Session folder structure (updated):**
```
data/<session-id>/
├── workspace_raw/       # original (never touched)
├── workspace/           # current active version
├── repair_history/      # NEW: snapshots before each repair
│   ├── round_01/
│   ├── round_02/
├── generated_tests/
├── reports/
└── session.json
```

**New API endpoints:**
- GET /api/session/{id}/versions
- POST /api/session/{id}/restore/{round}

12 new tests. Full suite: 335 passed.

Closes #T-033