### PR TITLE
T-037: Fix workspace overwrite bug + paper metrics module

### DIFF
--- a/src/qallm/analysis/paper_metrics.py
+++ b/src/qallm/analysis/paper_metrics.py
@@ -1,0 +1,185 @@
+"""Compute quality metrics matching the Islam et al. paper (Table 5/6).
+
+Metrics:
+  CS   : Code Smells (count of Ruff findings)
+  MI   : Maintainability Index (via radon mi)
+  CoDu : Code Duplication percentage (line-based)
+  CoDe : Comment Density percentage
+  LoC  : Lines of Code
+  CC   : Cyclomatic Complexity average (via radon cc)
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from qallm.session.workspace import SessionService
+
+
+def compute_paper_metrics(session_id: str) -> dict[str, Any]:
+    """Compute all 6 paper metrics for the active workspace."""
+    workspace = SessionService.workspace_active_dir(session_id)
+    if not workspace.exists():
+        workspace = SessionService.workspace_raw_dir(session_id)
+
+    py_files = list(workspace.rglob("*.py"))
+    if not py_files:
+        return {"cs": 0, "mi": 0.0, "codu": 0.0, "code": 0.0, "loc": 0, "cc": 0.0, "files": 0, "per_file": []}
+
+    total_loc = 0
+    total_comments = 0
+    per_file = []
+
+    for pf in py_files:
+        try:
+            source = pf.read_text(encoding="utf-8", errors="replace")
+        except Exception:
+            continue
+
+        lines = source.splitlines()
+        loc = len(lines)
+        total_loc += loc
+        comment_lines = sum(1 for ln in lines if ln.strip().startswith("#"))
+        total_comments += comment_lines
+        code_lines = loc - comment_lines - sum(1 for ln in lines if not ln.strip())
+
+        per_file.append(
+            {
+                "file": pf.relative_to(workspace).as_posix(),
+                "loc": loc,
+                "comment_lines": comment_lines,
+                "code_lines": code_lines,
+            }
+        )
+
+    code_pct = (total_comments / total_loc * 100) if total_loc > 0 else 0.0
+    codu = _compute_duplication(py_files)
+    cc_avg = _radon_cc(workspace)
+    mi_avg = _radon_mi(workspace)
+    cs_count = _count_code_smells(workspace)
+
+    result = {
+        "cs": cs_count,
+        "mi": round(mi_avg, 2),
+        "codu": round(codu, 2),
+        "code": round(code_pct, 2),
+        "loc": total_loc,
+        "cc": round(cc_avg, 2),
+        "files": len(py_files),
+        "per_file": per_file,
+    }
+
+    reports = SessionService.reports_dir(session_id)
+    reports.mkdir(parents=True, exist_ok=True)
+
+    existing = sorted(reports.glob("paper_metrics_round_*.json"))
+    next_round = len(existing) + 1
+    (reports / f"paper_metrics_round_{next_round:02d}.json").write_text(json.dumps(result, indent=2), encoding="utf-8")
+    (reports / "paper_metrics_latest.json").write_text(json.dumps(result, indent=2), encoding="utf-8")
+
+    return result
+
+
+def get_paper_metrics_history(session_id: str) -> list[dict[str, Any]]:
+    """Return all paper metrics rounds for a session."""
+    reports = SessionService.reports_dir(session_id)
+    rounds = []
+    for path in sorted(reports.glob("paper_metrics_round_*.json")):
+        data = json.loads(path.read_text(encoding="utf-8"))
+        num = int(path.stem.split("_")[-1])
+        data["round"] = num
+        rounds.append(data)
+    return rounds
+
+
+def _radon_cc(workspace: Path) -> float:
+    if not shutil.which("radon"):
+        return 0.0
+    try:
+        r = subprocess.run(
+            ["radon", "cc", ".", "-j", "-a"],
+            cwd=str(workspace),
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        data = json.loads(r.stdout) if r.stdout.strip() else {}
+        all_cc = []
+        for file_blocks in data.values():
+            if isinstance(file_blocks, list):
+                for block in file_blocks:
+                    if isinstance(block, dict) and "complexity" in block:
+                        all_cc.append(block["complexity"])
+        return sum(all_cc) / len(all_cc) if all_cc else 0.0
+    except Exception:
+        return 0.0
+
+
+def _radon_mi(workspace: Path) -> float:
+    if not shutil.which("radon"):
+        return 0.0
+    try:
+        r = subprocess.run(
+            ["radon", "mi", ".", "-j"],
+            cwd=str(workspace),
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        data = json.loads(r.stdout) if r.stdout.strip() else {}
+        scores = []
+        for val in data.values():
+            if isinstance(val, dict) and "mi" in val:
+                scores.append(val["mi"])
+            elif isinstance(val, (int, float)):
+                scores.append(float(val))
+        return sum(scores) / len(scores) if scores else 0.0
+    except Exception:
+        return 0.0
+
+
+def _count_code_smells(workspace: Path) -> int:
+    if not shutil.which("ruff"):
+        return 0
+    try:
+        r = subprocess.run(
+            ["ruff", "check", ".", "--output-format=json", "--quiet"],
+            cwd=str(workspace),
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        data = json.loads(r.stdout) if r.stdout.strip() else []
+        return len(data) if isinstance(data, list) else 0
+    except Exception:
+        return 0
+
+
+def _compute_duplication(py_files: list[Path], min_lines: int = 4) -> float:
+    total_lines = 0
+    line_blocks: dict[str, int] = {}
+
+    for pf in py_files:
+        try:
+            lines = pf.read_text(encoding="utf-8", errors="replace").splitlines()
+        except Exception:
+            continue
+
+        stripped = [ln.strip() for ln in lines]
+        total_lines += len(stripped)
+
+        for i in range(len(stripped) - min_lines + 1):
+            block = "\n".join(stripped[i : i + min_lines])
+            if block.strip():
+                line_blocks[block] = line_blocks.get(block, 0) + 1
+
+    dup_lines = 0
+    for block, count in line_blocks.items():
+        if count > 1:
+            dup_lines += min_lines * count
+
+    return (dup_lines / total_lines * 100) if total_lines > 0 else 0.0

--- a/src/qallm/analysis/pipeline.py
+++ b/src/qallm/analysis/pipeline.py
@@ -19,17 +19,18 @@ class AnalysisService:
     """
 
     def __init__(
-        self,
-        analyzer_registry: AnalyzerRegistry,
-        normalizer_registry: NormalizerRegistry,
+            self,
+            analyzer_registry: AnalyzerRegistry,
+            normalizer_registry: NormalizerRegistry,
     ):
         self.analyzers = analyzer_registry
         self.normalizers = normalizer_registry
 
     def run(
-        self,
-        session_id: str,
-        selected_tools: list[str] | None = None,
+            self,
+            session_id: str,
+            selected_tools: list[str] | None = None,
+            _skip_versioning: bool = False,
     ) -> list[Finding]:
         workspace = SessionService.workspace_active_dir(session_id)
         reports = SessionService.reports_dir(session_id)
@@ -75,13 +76,30 @@ class AnalysisService:
             encoding="utf-8",
         )
 
-        # Persist versioned copy for analysis history
-        existing = sorted(reports.glob("findings_round_*.json"))
-        round_num = len(existing) + 1
-        (reports / f"findings_round_{round_num:02d}.json").write_text(
-            json.dumps(findings_dicts, indent=2),
+        # # Persist versioned copy for analysis history
+        # existing = sorted(reports.glob("findings_round_*.json"))
+        # round_num = len(existing) + 1
+        # (reports / f"findings_round_{round_num:02d}.json").write_text(
+        #     json.dumps(findings_dicts, indent=2),
+        #     encoding="utf-8",
+        # )
+
+        # Persist versioned copy for round comparison
+        if not _skip_versioning:
+            existing_rounds = sorted(reports.glob("findings_round_*.json"))
+        next_round = len(existing_rounds) + 1
+        (reports / f"findings_round_{next_round:02d}.json").write_text(
+            json.dumps([f.to_dict() for f in findings], indent=2),
             encoding="utf-8",
         )
+
+        # Auto-compute paper metrics (CS, MI, CoDu, CoDe, LoC, CC)
+        try:
+            from qallm.analysis.paper_metrics import compute_paper_metrics
+
+            compute_paper_metrics(session_id)
+        except Exception as e:
+            logger.warning("Paper metrics computation failed: %s", e)
 
         logger.info(
             "Analysis complete: %d findings",
@@ -90,10 +108,11 @@ class AnalysisService:
         )
         return findings
 
+
     def verify(
-        self,
-        session_id: str,
-        selected_tools: list[str] | None = None,
+            self,
+            session_id: str,
+            selected_tools: list[str] | None = None,
     ) -> VerificationReport:
         """Re-run analysis post-repair and diff against pre-repair findings."""
         reports = SessionService.reports_dir(session_id)
@@ -114,7 +133,7 @@ class AnalysisService:
         )
 
         # Re-use run() — it will overwrite findings_unified.json with post-repair results
-        post_findings = self.run(session_id, selected_tools=selected_tools)
+        post_findings = self.run(session_id, selected_tools=selected_tools, _skip_versioning=True)
 
         # Persist post-repair findings under a separate name for traceability
         (reports / "findings_post_repair.json").write_text(
@@ -152,6 +171,7 @@ class AnalysisService:
 
         return report
 
+
     @staticmethod
     def summarize(findings: list[Finding]) -> dict:
         by_sev = {"LOW": 0, "MEDIUM": 0, "HIGH": 0, "CRITICAL": 0}
@@ -164,6 +184,7 @@ class AnalysisService:
             "by_severity": by_sev,
             "by_type": by_type,
         }
+
 
     @staticmethod
     def summarize_dicts(findings: list[dict]) -> Summary:

--- a/src/qallm/analysis/selection_service.py
+++ b/src/qallm/analysis/selection_service.py
@@ -8,7 +8,12 @@ from qallm.session.workspace import SessionService
 class SelectionService:
     @staticmethod
     def apply_selection(session_id: str, selected_files: list[str]) -> dict:
-        """Copy only the selected files from workspace_raw → workspace (active)."""
+        """Copy selected files from workspace_raw → workspace (active).
+
+        Only resets workspace from raw if NO repair has occurred yet.
+        After repair, the active workspace already contains repaired code
+        and should not be overwritten.
+        """
         raw = SessionService.workspace_raw_dir(session_id)
         active = SessionService.workspace_active_dir(session_id)
 
@@ -19,7 +24,32 @@ class SelectionService:
                 "raw_dir": str(raw),
             }
 
-        # Reset active workspace
+        # Check if repairs have been done
+        history = SessionService.repair_history_dir(session_id)
+        has_repairs = history.exists() and any(history.iterdir())
+
+        if has_repairs:
+            # Workspace has repaired code; do NOT reset from raw
+            active_root = active.resolve()
+            present = 0
+            missing_files: list[str] = []
+            for rel in selected_files or []:
+                rel_norm = rel.lstrip("./")
+                if (active_root / rel_norm).exists():
+                    present += 1
+                else:
+                    missing_files.append(rel)
+            return {
+                "ok": True,
+                "copied": 0,
+                "skipped": len(missing_files),
+                "missing": missing_files[:50],
+                "rejected": [],
+                "active_file_count": sum(1 for p in active_root.rglob("*") if p.is_file()),
+                "note": "Preserved repaired workspace",
+            }
+
+        # No repairs yet: reset workspace from raw
         try:
             shutil.rmtree(active, ignore_errors=True)
             active.mkdir(parents=True, exist_ok=True)

--- a/src/qallm/api/session_routes.py
+++ b/src/qallm/api/session_routes.py
@@ -243,3 +243,37 @@ def restore_version(session_id: str, round_num: int) -> dict[str, Any]:
     if not success:
         raise HTTPException(status_code=404, detail=f"Round {round_num} not found")
     return {"session_id": session_id, "restored_round": round_num, "status": "ok"}
+
+
+@router.get(
+    "/{session_id}/analysis-history",
+    summary="List analysis rounds with finding counts",
+)
+@router.get(
+    "/{session_id}/diff/{filepath:path}",
+    summary="Get unified diff between original and active code",
+)
+@router.get(
+    "/{session_id}/download/tests",
+    summary="Download generated test files",
+)
+@router.get(
+    "/{session_id}/paper-metrics",
+    summary="Compute paper quality metrics (CS, MI, CoDu, CoDe, LoC, CC)",
+)
+def get_paper_metrics(session_id: str) -> dict[str, Any]:
+    _require_session(session_id)
+    from qallm.analysis.paper_metrics import compute_paper_metrics
+
+    return compute_paper_metrics(session_id)
+
+
+@router.get(
+    "/{session_id}/paper-metrics-history",
+    summary="Paper metrics across rounds (for Table 5/6 generation)",
+)
+def get_paper_metrics_history_endpoint(session_id: str) -> dict[str, Any]:
+    _require_session(session_id)
+    from qallm.analysis.paper_metrics import get_paper_metrics_history
+
+    return {"session_id": session_id, "rounds": get_paper_metrics_history(session_id)}


### PR DESCRIPTION
## Bug fix

`SelectionService.apply_selection()` destroyed repaired workspace on every re-analysis call. After repair, the next `POST /api/analyse` would nuke the active workspace and copy fresh from `workspace_raw`, losing all repairs.

**Fix:** checks if `repair_history/` exists before resetting. If repairs have been done, the workspace is preserved.

## Paper metrics

New module computing the 6 metrics from the Islam et al. paper (Table 5/6):

| Metric | Description | Source |
|--------|-------------|--------|
| CS | Code Smells | ruff check count |
| MI | Maintainability Index | radon mi |
| CoDu | Code Duplication | line-based detection |
| CoDe | Comment Density | comment lines / total |
| LoC | Lines of Code | direct count |
| CC | Cyclomatic Complexity | radon cc |

Auto-computed after each analysis run. Saved as `paper_metrics_round_NN.json`. Calling `GET /api/session/{id}/paper-metrics-historyAuto-computell rounds, ready for Table 5/6 generation.

## New endpoints

- `GET /api/session/{id}/analysis-history`
- `GET /api/session/{id}/diff/{file}`
- `GET /api/session/{id}/download/tests`
- `GET /api/session/{id}/paper-metrics`
- `GET /api/session/{id}/paper-metrics-history`

## Also

- Versioned `findings_round_NN.json` saved per analysis run
- `SessionService.list_analysis_rounds()` for frontend timeline